### PR TITLE
Feature-create-update-module-workflow

### DIFF
--- a/basepair/api.py
+++ b/basepair/api.py
@@ -426,26 +426,25 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   def create_module(self, data):
     '''create module from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
-    with open(path,'r') as fp:
-      yaml_string = fp.read()
-    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    with open(path, 'r') as file:
+      yaml_string = file.read()
+    yaml_data = yaml.load(yaml_string, Loader=yaml.FullLoader)
     if not yaml_data.get('name'):
       eprint('Please provide module name in YAML')
       return
-    payload = {'data':yaml_string}
+    payload = {'data': yaml_string}
     info = (Module(self.conf.get('api'))).save(payload=payload)
     if info.get('error'):
       if 'already exists' in info['error']:
         if data['force']:
           eprint('Using force override the existing resource')
           self.update_module(data)
-          return
         else:
-          answer = self.yes_or_no('A module with ID {} already exists, do you want to overwrite it? (y/n)?'.format(yaml_data.get('id')))
+          answer = BpApi.yes_or_no(
+            f'A module with ID {yaml_data.get("id")} already exists, do you want to overwrite it?')
           if answer:
             self.update_module(data)
-            return
-          return
+        return
     module_id = info.get('id')
     module_name = info.get('name')
     if module_id:  # success
@@ -455,21 +454,21 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       eprint('failed module creation')
     return
 
-  def update_module(self,data):
+  def update_module(self, data):
     '''update module from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
-    with open(path,'r') as fp:
-      yaml_string = fp.read()
-    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    with open(path, 'r') as file:
+      yaml_string = file.read()
+    yaml_data = yaml.load(yaml_string, Loader=yaml.FullLoader)
     module_id = yaml_data.get('id')
     if not yaml_data.get('name'):
       eprint('Please provide module name in YAML')
-      return None
+      return
     if not module_id:
       eprint('Please provide module id in YAML')
-      return None
-    payload = {'data':yaml_string}
-    info = (Module(self.conf.get('api'))).save(obj_id=module_id,payload=payload)
+      return
+    payload = {'data': yaml_string}
+    info = (Module(self.conf.get('api'))).save(obj_id=module_id, payload=payload)
     module_id = info.get('id')
     if module_id:  # success
       if self.verbose:
@@ -478,14 +477,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     else:  # failure
       eprint('failed module update')
     return
-  
+
   def get_module(self, uid):
     '''Get module resource'''
     return (Module(self.conf.get('api'))).get(
         uid,
         cache='{}/json/module.{}.json'.format(self.scratch, uid) if self.use_cache else False,
     )
-  
+
   def delete_module(self, uid):
     '''Delete method'''
     info = (Module(self.conf.get('api'))).delete(uid)
@@ -503,26 +502,25 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   def create_pipeline(self,data):
     '''create pipeline from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
-    with open(path,'r') as fp:
-      yaml_string = fp.read()
-    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    with open(path, 'r') as file:
+      yaml_string = file.read()
+    yaml_data = yaml.load(yaml_string, Loader=yaml.FullLoader)
     if not yaml_data.get('name'):
       eprint('Please provide workflow name in YAML')
       return
-    payload = {'data':yaml_string}
+    payload = {'data': yaml_string}
     info = (Pipeline(self.conf.get('api'))).save(payload=payload)
     if info.get('error'):
       if 'already exists' in info['error']:
         if data['force']:
           eprint('Using force override the existing resource')
           self.update_pipeline(data)
-          return
         else:
-          answer = self.yes_or_no('A pipeline with ID {} already exists, do you want to overwrite it? (y/n)?'.format(yaml_data.get('id')))
+          answer = BpApi.yes_or_no(
+            f'A pipeline with ID {yaml_data.get("id")} already exists, do you want to overwrite it?')
           if answer:
             self.update_pipeline(data)
-            return
-          return
+        return
     workflow_id = info.get('id')
     workflow_name = info.get('name')
     if workflow_id:  # success
@@ -535,9 +533,9 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   def update_pipeline(self,data):
     '''update pipeline from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
-    with open(path,'r') as fp:
-      yaml_string = fp.read()
-    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    with open(path, 'r') as file:
+      yaml_string = file.read()
+    yaml_data = yaml.load(yaml_string, Loader=yaml.FullLoader)
     workflow_id = yaml_data.get('id')
     if not yaml_data.get('name'):
       eprint('Please provide workflow name in YAML')
@@ -545,8 +543,8 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     if not yaml_data.get('id'):
       eprint('Please provide workflow id in YAML')
       return
-    payload = {'data':yaml_string}
-    info = (Pipeline(self.conf.get('api'))).save(obj_id=workflow_id,payload=payload)
+    payload = {'data': yaml_string}
+    info = (Pipeline(self.conf.get('api'))).save(obj_id=workflow_id, payload=payload)
     workflow_id = info.get('id')
     if workflow_id:  # success
       if self.verbose:
@@ -555,7 +553,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     else:  # failure
       eprint('failed pipeline update')
     return
-  
+
   def get_pipeline(self, uid):
     '''Get resource'''
     return (Pipeline(self.conf.get('api'))).get(
@@ -1382,7 +1380,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     list_methods = {
       'analyses': 'get_analyses',
       'genomes': 'get_genomes',
-      'pipeline_modules':'get_pipeline_modules',
+      'pipeline_modules': 'get_pipeline_modules',
       'samples': 'get_samples',
       'pipelines': 'get_pipelines'
     }
@@ -1459,7 +1457,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
 
   def _check_workflow(self, uid):
     '''Check if the workflow is in the Basepair database'''
-    info = self.get_workflow(uid)
+    info = self.get_pipeline(uid)
     if info.get('id'):
       return True
     eprint('The provided workflow id: {id}, does not exist in Basepair.'.format(id=uid))
@@ -1523,7 +1521,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     )
     self.conf['user'] = user.get('objects', [None])[0]
 
-  def yes_or_no(self,question):
+  @classmethod
+  def _parsed_sample_list(cls, items, prefix):
+    '''Parse sample id list into sample resource uri list'''
+    return ['{}samples/{}'.format(prefix, item_id) for item_id in items]
+
+  @staticmethod
+  def yes_or_no(question):
+    '''Helper to get user response'''
     valid = {
       'yes': True,
       'y': True,
@@ -1535,15 +1540,10 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
 
     while True:
       # get input from user
-      sys.stdout.write(question + prompt)
+      sys.stdout.write(f'{question}{prompt}')
       choice = input().lower()
 
       # check answer
       if choice in valid:
         return valid[choice]
       sys.stdout.write('Please respond with \'yes\' or \'no\' (or \'y\' or \'n\').\n')
-
-  @classmethod
-  def _parsed_sample_list(cls, items, prefix):
-    '''Parse sample id list into sample resource uri list'''
-    return ['{}samples/{}'.format(prefix, item_id) for item_id in items]

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -27,6 +27,7 @@ import subprocess
 from subprocess import CalledProcessError
 import time
 import datetime
+import yaml
 
 # App imports
 from .helpers import eprint, NicePrint, SetFilter
@@ -415,6 +416,52 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   ################################################################################################
   ### MODULE #####################################################################################
   ################################################################################################
+  def create_module(self,data):
+    path = os.path.abspath(os.path.expanduser(
+          os.path.expandvars(data['yamlpath'])
+      ))
+    with open(path,'r') as fp:
+      yaml_string = fp.read()
+    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    if yaml_data.get('name') == None:
+      eprint('Please provide module name in YAML')
+      return None
+    payload = {"data":yaml_string}
+    info = (Module(self.conf.get('api'))).save(payload=payload)
+    module_id = info.get('id')
+    module_name = info.get('name')
+    if module_id:  # success
+      if self.verbose:
+        eprint('created: module '+module_name+' with id', module_id)
+    else:  # failure
+      eprint('failed module creation:', info.get('msg'))
+    return module_id
+
+  def update_module(self,data):
+    path = os.path.abspath(os.path.expanduser(
+          os.path.expandvars(data['yamlpath'])
+      ))
+    with open(path,'r') as fp:
+      yaml_string = fp.read()
+    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    module_id = yaml_data.get('id')
+    if yaml_data.get('name') == None:
+      eprint('Please provide module name in YAML')
+      return None
+    if yaml_data.get('id') == None:
+      eprint('Please provide module id in YAML')
+      return None
+    payload = {"data":yaml_string}
+    info = (Module(self.conf.get('api'))).save(obj_id=module_id,payload=payload)
+    module_id = info.get('id')
+    if module_id:  # success
+      if self.verbose:
+        module_name = info.get('name')
+        eprint('updated: module '+module_name+' with id', module_id)
+    else:  # failure
+      eprint('failed module creation:', info.get('msg'))
+    return module_id
+  
   def get_module(self, uid):
     '''Get resource'''
     return (Module(self.conf.get('api'))).get(
@@ -425,6 +472,52 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   ################################################################################################
   ### PIPELINE / WORKFLOW ########################################################################
   ################################################################################################
+  def create_workflow(self,data):
+    path = os.path.abspath(os.path.expanduser(
+          os.path.expandvars(data['yamlpath'])
+      ))
+    with open(path,'r') as fp:
+      yaml_string = fp.read()
+    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    if yaml_data.get('name') == None:
+      eprint('Please provide workflow name in YAML')
+      return None
+    payload = {"data":yaml_string}
+    info = (Pipeline(self.conf.get('api'))).save(payload=payload)
+    workflow_id = info.get('id')
+    workflow_name = info.get('name')
+    if workflow_id:  # success
+      if self.verbose:
+        eprint('created: workflow '+workflow_name+' with id', workflow_id)
+    else:  # failure
+      eprint('failed workflow creation:')
+    return workflow_id
+
+  def update_workflow(self,data):
+    path = os.path.abspath(os.path.expanduser(
+          os.path.expandvars(data['yamlpath'])
+      ))
+    with open(path,'r') as fp:
+      yaml_string = fp.read()
+    yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
+    workflow_id = yaml_data.get('id')
+    if yaml_data.get('name') == None:
+      eprint('Please provide workflow name in YAML')
+      return None
+    if yaml_data.get('id') == None:
+      eprint('Please provide workflow id in YAML')
+      return None
+    payload = {"data":yaml_string}
+    info = (Pipeline(self.conf.get('api'))).save(obj_id=workflow_id,payload=payload)
+    workflow_id = info.get('id')
+    if workflow_id:  # success
+      if self.verbose:
+        workflow_name = info.get('name')
+        eprint('updated: workflow '+workflow_name+' with id', workflow_id)
+    else:  # failure
+      eprint('failed workflow update:', info.get('msg'))
+    return workflow_id
+  
   def get_workflow(self, uid):
     '''Get resource'''
     return (Pipeline(self.conf.get('api'))).get(

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -445,13 +445,12 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
           if answer:
             self.update_module(data)
         return
+      eprint('failed module creation')
+      return
     module_id = info.get('id')
     module_name = info.get('name')
-    if module_id:  # success
-      if self.verbose:
-        eprint(f'created: module {module_name} with id {module_id}')
-    else:  # failure
-      eprint('failed module creation')
+    if self.verbose:
+      eprint(f'created: module {module_name} with id {module_id}')
     return
 
   def update_module(self, data):
@@ -469,13 +468,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       return
     payload = {'data': yaml_string}
     info = (Module(self.conf.get('api'))).save(obj_id=module_id, payload=payload)
-    module_id = info.get('id')
-    if module_id:  # success
-      if self.verbose:
-        module_name = info.get('name')
-        eprint(f'updated: module {module_name} with id {module_id}')
-    else:  # failure
+    if info.get('error'):
       eprint('failed module update')
+      return
+
+    module_id = info.get('id')
+    if self.verbose:
+      module_name = info.get('name')
+      eprint(f'updated: module {module_name} with id {module_id}')
     return
 
   def get_module(self, uid):
@@ -521,13 +521,12 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
           if answer:
             self.update_pipeline(data)
         return
+      eprint('failed pipeline creation')
+      return
     workflow_id = info.get('id')
     workflow_name = info.get('name')
-    if workflow_id:  # success
-      if self.verbose:
-        eprint(f'created: workflow {workflow_name} with id {workflow_id}')
-    else:  # failure
-      eprint('failed pipeline creation')
+    if self.verbose:
+      eprint(f'created: workflow {workflow_name} with id {workflow_id}')
     return
 
   def update_pipeline(self,data):
@@ -545,13 +544,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       return
     payload = {'data': yaml_string}
     info = (Pipeline(self.conf.get('api'))).save(obj_id=workflow_id, payload=payload)
-    workflow_id = info.get('id')
-    if workflow_id:  # success
-      if self.verbose:
-        workflow_name = info.get('name')
-        eprint(f'updated: workflow {workflow_name} with id {workflow_id}')
-    else:  # failure
+    if info.get('error'):
       eprint('failed pipeline update')
+      return
+
+    workflow_id = info.get('id')
+    if self.verbose:
+      workflow_name = info.get('name')
+      eprint(f'updated: workflow {workflow_name} with id {workflow_id}')
     return
 
   def get_pipeline(self, uid):

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -416,28 +416,28 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   ################################################################################################
   ### MODULE #####################################################################################
   ################################################################################################
-  def create_module(self,data):
-    path = os.path.abspath(os.path.expanduser(
-          os.path.expandvars(data['yamlpath'])
-      ))
+  def create_module(self, data):
+    '''create module from yaml'''
+    path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()
     yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
     if yaml_data.get('name') == None:
       eprint('Please provide module name in YAML')
       return None
-    payload = {"data":yaml_string}
+    payload = {'data':yaml_string}
     info = (Module(self.conf.get('api'))).save(payload=payload)
     module_id = info.get('id')
     module_name = info.get('name')
     if module_id:  # success
       if self.verbose:
-        eprint('created: module '+module_name+' with id', module_id)
+        eprint(f'created: module {module_name} with id {module_id}')
     else:  # failure
-      eprint('failed module creation:', info.get('msg'))
-    return module_id
+      eprint('failed module creation:', info.get('error'))
+    return None
 
   def update_module(self,data):
+    '''update module from yaml'''
     path = os.path.abspath(os.path.expanduser(
           os.path.expandvars(data['yamlpath'])
       ))
@@ -448,19 +448,19 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     if yaml_data.get('name') == None:
       eprint('Please provide module name in YAML')
       return None
-    if yaml_data.get('id') == None:
+    if module_id == None:
       eprint('Please provide module id in YAML')
       return None
-    payload = {"data":yaml_string}
+    payload = {'data':yaml_string}
     info = (Module(self.conf.get('api'))).save(obj_id=module_id,payload=payload)
     module_id = info.get('id')
     if module_id:  # success
       if self.verbose:
         module_name = info.get('name')
-        eprint('updated: module '+module_name+' with id', module_id)
+        eprint(f'updated: module {module_name} with id {module_id}')
     else:  # failure
-      eprint('failed module creation:', info.get('msg'))
-    return module_id
+      eprint('failed module creation:', info.get('error'))
+    return None
   
   def get_module(self, uid):
     '''Get resource'''
@@ -477,30 +477,28 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   ### PIPELINE / WORKFLOW ########################################################################
   ################################################################################################
   def create_workflow(self,data):
-    path = os.path.abspath(os.path.expanduser(
-          os.path.expandvars(data['yamlpath'])
-      ))
+    '''create pipeline from yaml'''
+    path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()
     yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
     if yaml_data.get('name') == None:
       eprint('Please provide workflow name in YAML')
       return None
-    payload = {"data":yaml_string}
+    payload = {'data':yaml_string}
     info = (Pipeline(self.conf.get('api'))).save(payload=payload)
     workflow_id = info.get('id')
     workflow_name = info.get('name')
     if workflow_id:  # success
       if self.verbose:
-        eprint('created: workflow '+workflow_name+' with id', workflow_id)
+        eprint(f'created: workflow {workflow_name} with id {workflow_id}')
     else:  # failure
-      eprint('failed workflow creation:',info.get('msg'))
-    return workflow_id
+      eprint('failed workflow creation:',info.get('error'))
+    return None
 
   def update_workflow(self,data):
-    path = os.path.abspath(os.path.expanduser(
-          os.path.expandvars(data['yamlpath'])
-      ))
+    '''update pipeline from yaml'''
+    path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()
     yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)
@@ -511,16 +509,16 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     if yaml_data.get('id') == None:
       eprint('Please provide workflow id in YAML')
       return None
-    payload = {"data":yaml_string}
+    payload = {'data':yaml_string}
     info = (Pipeline(self.conf.get('api'))).save(obj_id=workflow_id,payload=payload)
     workflow_id = info.get('id')
     if workflow_id:  # success
       if self.verbose:
         workflow_name = info.get('name')
-        eprint('updated: workflow '+workflow_name+' with id', workflow_id)
+        eprint(f'updated: workflow {workflow_name} with id {workflow_id}')
     else:  # failure
-      eprint('failed workflow update:', info.get('msg'))
-    return workflow_id
+      eprint('failed workflow update:', info.get('error'))
+    return None
   
   def get_workflow(self, uid):
     '''Get resource'''

--- a/basepair/helpers/nice_print.py
+++ b/basepair/helpers/nice_print.py
@@ -192,7 +192,7 @@ class NicePrint:
     ]))
 
   @staticmethod
-  def workflows(data):
+  def pipelines(data):
     '''Print pipelines'''
     to_print = [
       [
@@ -212,7 +212,7 @@ class NicePrint:
     ]))
 
   @staticmethod
-  def workflow(data):
+  def pipeline(data):
     '''Print pipeline'''
     to_print = [
       [

--- a/basepair/infra/webapp/module.py
+++ b/basepair/infra/webapp/module.py
@@ -22,8 +22,7 @@ class Module(Abstract):
         verify=verify,
       )
       parsed = self._parse_response(response)
-      result = parsed.get('objects')
-      return result
+      return parsed.get('objects')
     except requests.exceptions.RequestException as error:
       eprint('ERROR: {}'.format(error))
       return {'error': True, 'msg': error}

--- a/bin/basepair
+++ b/bin/basepair
@@ -100,8 +100,8 @@ def main():
       create_project(bp, args)
     if args.create_type == 'module':
       create_module(bp, args)
-    if args.create_type == 'workflow':
-      create_workflow(bp, args)
+    if args.create_type == 'pipeline':
+      create_pipeline(bp, args)
 
     if args.create_type == 'sample':
 
@@ -129,8 +129,8 @@ def main():
       update_sample(bp, args)
     if args.update_type == 'module':
       update_module(bp, args)
-    if args.update_type == 'workflow':
-      update_workflow(bp, args)
+    if args.update_type == 'pipeline':
+      update_pipeline(bp, args)
   elif args.action == 'download':
     if args.download_type == 'analysis':
       download_analysis(bp, args)
@@ -145,28 +145,29 @@ def main():
       download_sample(bp, args)
 
   elif args.action == 'delete':
-    delete(bp, args.type, args.uid)
+    delete(bp, args.delete_type, args.uid)
   elif args.action == 'list':
-
-    if args.list_type == 'analysis':
-      _list_item(bp, data_type='analysis', uids=args.uid, is_json=args.json)
     if args.list_type == 'analyses':
       bp.print_data(data_type='analyses', is_json=args.json, project=args.project)
     elif args.list_type == 'genomes':
       bp.print_data(data_type='genomes', is_json=args.json)
-    elif args.list_type == 'sample':
-      _list_item(bp, data_type='sample', uids=args.uid, is_json=args.json)
     elif args.list_type == 'pipeline_modules':
       _list_item(bp, data_type='pipeline_modules', uids=args.uid, is_json=args.json)
-    elif args.list_type == 'module':
-      _list_item(bp, data_type='module', uids=args.uid, is_json=args.json)
     elif args.list_type == 'samples':
       bp.print_data(data_type='samples', is_json=args.json, project=args.project)
-    elif args.list_type == 'workflows':
-      bp.print_data(data_type='workflows', is_json=args.json)
-    elif args.list_type == 'workflow':
-      _list_item(bp, data_type='workflow', uids=args.uid, is_json=args.json)
-    elif args.list_type == 'genome':
+    elif args.list_type == 'pipelines':
+      bp.print_data(data_type='pipelines', is_json=args.json)
+
+  elif args.action == 'get':
+    if args.get_type == 'analysis':
+      _list_item(bp, data_type='analysis', uids=args.uid, is_json=args.json)
+    elif args.get_type == 'sample':
+      _list_item(bp, data_type='sample', uids=args.uid, is_json=args.json)
+    elif args.get_type == 'module':
+      _list_item(bp, data_type='module', uids=args.uid, is_json=args.json)
+    elif args.get_type == 'pipeline':
+      _list_item(bp, data_type='pipeline', uids=args.uid, is_json=args.json)
+    elif args.get_type == 'genome':
       _list_item(bp, data_type='genome', uids=args.uid, is_json=args.json)
 
 
@@ -225,35 +226,36 @@ def create_analysis(bp, args):
     workflow_id=args.workflow,
   )
 
+def check_yaml(args):
+  '''Checks yaml file'''
+  if not args.file:
+    eprint('ERROR: Yaml file required.')
+    return False
+  if len(args.file) != 1:
+    eprint('Please provide only one yaml')
+    return False
+  yaml_path = args.file[0]
+  valid_extensions = ('.yaml', '.yml')
+  if yaml_path.endsWith(valid_extensions):
+    return True
+  eprint('Please provide yaml file only')
+  return False
+
 def create_module(bp, args):
   '''Create module'''
-  if not args.yaml:
-    eprint('ERROR: Yaml file required.')
+  valid = check_yaml(args)
+  if valid:
+    bp.create_module({'yamlpath': args.file[0], 'force':args.force})
     return
-  if len(args.yaml) != 1:
-    eprint('Please provide only one yaml')
-    return
-  yaml_path = args.yaml[0]
-  if args.yaml[0].endswith('.yaml'):
-    bp.create_module({'yamlpath': yaml_path})
-  else:
-    eprint('Please provide yaml file only')
-    return
+  return
 
-def create_workflow(bp, args):
-  '''Create workflow'''
-  if not args.yaml:
-    eprint('ERROR: Yaml file required.')
+def create_pipeline(bp, args):
+  '''Create pipeline'''
+  valid = check_yaml(args)
+  if valid:
+    bp.create_pipeline({'yamlpath': args.file[0], 'force':args.force})
     return
-  if len(args.yaml) != 1:
-    eprint('Please provide only one yaml')
-    return
-  yaml_path = args.yaml[0]
-  if args.yaml[0].endswith('.yaml'):
-    bp.create_workflow({'yamlpath': yaml_path})
-  else:
-    eprint('Please provide yaml file only')
-    return
+  return
 
 def download_analysis(bp, args):
   '''Download analysis'''
@@ -392,36 +394,28 @@ def update_analysis(bp, analysis_id, keys, vals):
 
 def update_module(bp, args):
   '''Update module'''
-  if not args.yaml:
-    eprint('ERROR: Yaml file required.')
+  valid = check_yaml(args)
+  if valid:
+    bp.update_module({'yamlpath': args.file[0]})
     return
-  if len(args.yaml) != 1:
-    eprint('Please provide only one yaml')
-    return
-  yaml_path = args.yaml[0]
-  if args.yaml[0].endswith('.yaml'):
-    bp.update_module({'yamlpath': yaml_path})
-  else:
-    eprint('Please provide yaml file only')
+  return
 
-def update_workflow(bp, args):
-  '''Update workflow'''
-  if not args.yaml:
-    eprint('ERROR: Yaml file required.')
+def update_pipeline(bp, args):
+  '''Update pipeline'''
+  valid = check_yaml(args)
+  if valid:
+    bp.update_pipeline({'yamlpath': args.file[0]})
     return
-  if len(args.yaml) != 1:
-    eprint('Please provide only one yaml')
-    return
-  yaml_path = args.yaml[0]
-  if args.yaml[0].endswith('.yaml'):
-    bp.update_workflow({'yamlpath': yaml_path})
-  else:
-    eprint('Please provide yaml file only')
+  return
 
 def delete(bp, data_type, uid):
   '''Delete object'''
   if not uid:
     eprint('Please add one or more uid')
+    return
+  
+  if not data_type:
+    eprint('Please add a datatype')
     return
 
   for uid in uid:
@@ -431,8 +425,8 @@ def delete(bp, data_type, uid):
         bp.delete_sample(uid)
       elif data_type == 'analysis':
         bp.delete_analysis(uid)
-      elif data_type == 'workflow':
-        bp.delete_workflow(uid)
+      elif data_type == 'pipeline':
+        bp.delete_pipeline(uid)
       elif data_type == 'module':
         bp.delete_module(uid)
 
@@ -517,14 +511,23 @@ def add_tags_parser(parser):
   return parser
 
 def add_yaml_parser(parser):
-  '''Add uid parser'''
+  '''Add yaml file parser'''
   parser.add_argument(
-    '-y',
-    '--yaml',
+    '-f',
+    '--file',
     default=None,
     required=True,
     help='The filepath of YAML',
     nargs='+'
+  )
+  return parser
+
+def add_force_parser(parser):
+  '''Add force parser'''
+  parser.add_argument(
+    '--force',
+    action='store_true',
+    help='(Optional) Override existing resource.'
   )
   return parser
 
@@ -616,14 +619,16 @@ def read_args():
   )
   create_module_p = add_common_args(create_module_p)
   create_module_p = add_yaml_parser(create_module_p)
+  create_module_p = add_force_parser(create_module_p)
 
   # create workflow parser
-  create_workflow_p = create_sp.add_parser(
-    'workflow',
-    help='Create workflow.'
+  create_pipeline_p = create_sp.add_parser(
+    'pipeline',
+    help='Create pipeline'
   )
-  create_workflow_p = add_common_args(create_workflow_p)
-  create_workflow_p = add_yaml_parser(create_workflow_p)
+  create_pipeline_p = add_common_args(create_pipeline_p)
+  create_pipeline_p = add_yaml_parser(create_pipeline_p)
+  create_pipeline_p = add_force_parser(create_pipeline_p)
 
   # update parser
   update_p = actions_p.add_parser(
@@ -685,12 +690,12 @@ def read_args():
   update_module_parser = add_yaml_parser(update_module_parser)
 
   # update workflow parser
-  update_workflow_parser = update_sp.add_parser(
-    'workflow',
-    help='Update information associated with a workflow.'
+  update_pipeline_parser = update_sp.add_parser(
+    'pipeline',
+    help='Update information associated with a pipeline'
   )
-  update_workflow_parser = add_common_args(update_workflow_parser)
-  update_workflow_parser = add_yaml_parser(update_workflow_parser)
+  update_pipeline_parser = add_common_args(update_pipeline_parser)
+  update_pipeline_parser = add_yaml_parser(update_pipeline_parser)
 
   # download parsers
   download_p = actions_p.add_parser('download', help='Download items.')
@@ -739,21 +744,86 @@ def read_args():
     'delete',
     help='Delete a sample or analysis from your Basepair account.'
   )
-  delete_parser = add_common_args(delete_parser)
-  delete_parser.add_argument(
-    '-t',
-    '--type',
-    choices=['analysis', 'sample', 'workflow', 'module'],
-    help='Type of data to delete. Options: sample, analysis, workflow, module',
-    required=True,
+  delete_sp = delete_parser.add_subparsers(
+    dest='delete_type',
+    help='Type of data to delete. Options: sample, analysis, pipeline, module',
   )
-  delete_parser.add_argument(
-    '-u',
-    '--uid',
-    default=None,
-    help=' The unique sample or analysis id(s)',
-    nargs='+',
+  delete_analysis_p = delete_sp.add_parser(
+    'analysis',
+    help='delete an analysis.'
   )
+  delete_analysis_p = add_common_args(delete_analysis_p)
+  delete_analysis_p = add_uid_parser(delete_analysis_p)
+
+  delete_sample_p = delete_sp.add_parser(
+    'sample',
+    help='delete a sample.'
+  )
+  delete_sample_p = add_common_args(delete_sample_p)
+  delete_sample_p = add_uid_parser(delete_sample_p)
+
+  delete_pipeline_p = delete_sp.add_parser(
+    'pipeline',
+    help='delete a pipeline.'
+  )
+  delete_pipeline_p = add_common_args(delete_pipeline_p)
+  delete_pipeline_p = add_uid_parser(delete_pipeline_p)
+
+  delete_module_p = delete_sp.add_parser(
+    'module',
+    help='delete a module.'
+  )
+  delete_module_p = add_common_args(delete_module_p)
+  delete_module_p = add_uid_parser(delete_module_p)
+
+  # get parser
+  get_p = actions_p.add_parser('get', help='Detail of an item.')
+
+  get_sp = get_p.add_subparsers(
+    dest='get_type',
+    help='Type of item to get detail',
+  )
+
+  get_analysis_p = get_sp.add_parser(
+    'analysis',
+    help='get files and other info for one or more analyses.'
+  )
+  get_analysis_p = add_common_args(get_analysis_p)
+  get_analysis_p = add_uid_parser(get_analysis_p)
+  get_analysis_p = add_json_parser(get_analysis_p)
+
+  get_sample_p = get_sp.add_parser(
+    'sample',
+    help='List detail info about one or more samples.'
+  )
+  get_sample_p = add_common_args(get_sample_p)
+  get_sample_p = add_uid_parser(get_sample_p)
+  get_sample_p = add_json_parser(get_sample_p)
+
+  get_pipeline_p = get_sp.add_parser(
+    'pipeline',
+    help='Detail a pipeline'
+  )
+  get_pipeline_p = add_common_args(get_pipeline_p)
+  get_pipeline_p = add_uid_parser(get_pipeline_p)
+  get_pipeline_p = add_json_parser(get_pipeline_p)
+
+  get_module_p = get_sp.add_parser(
+    'module',
+    help='Detail a module'
+  )
+  get_module_p = add_common_args(get_module_p)
+  get_module_p = add_uid_parser(get_module_p)
+  get_module_p = add_json_parser(get_module_p)
+
+  get_genome_p = get_sp.add_parser(
+    'genome',
+    help='List detail info about one or more genomes.'
+  )
+  get_genome_p = add_common_args(get_genome_p)
+  get_genome_p = add_uid_parser(get_genome_p)
+  get_genome_p = add_json_parser(get_genome_p)
+
 
   # list parser
   list_p = actions_p.add_parser('list', help='List of items.')
@@ -762,14 +832,6 @@ def read_args():
     dest='list_type',
     help='Type of item to list',
   )
-
-  list_analysis_p = list_sp.add_parser(
-    'analysis',
-    help='List files and other info for one or more analyses.'
-  )
-  list_analysis_p = add_common_args(list_analysis_p)
-  list_analysis_p = add_uid_parser(list_analysis_p)
-  list_analysis_p = add_json_parser(list_analysis_p)
 
   list_analyses_p = list_sp.add_parser(
     'analyses',
@@ -795,14 +857,6 @@ def read_args():
   list_samples_p = add_common_args(list_samples_p)
   list_samples_p = add_json_parser(list_samples_p)
 
-  list_sample_p = list_sp.add_parser(
-    'sample',
-    help='List detail info about one or more samples.'
-  )
-  list_sample_p = add_common_args(list_sample_p)
-  list_sample_p = add_uid_parser(list_sample_p)
-  list_sample_p = add_json_parser(list_sample_p)
-
   list_genomes_p = list_sp.add_parser(
     'genomes',
     help='List available genomes.'
@@ -810,28 +864,12 @@ def read_args():
   list_genomes_p = add_common_args(list_genomes_p)
   list_genomes_p = add_json_parser(list_genomes_p)
 
-  list_genome_p = list_sp.add_parser(
-    'genome',
-    help='List detail info about one or more genomes.'
-  )
-  list_genome_p = add_common_args(list_genome_p)
-  list_genome_p = add_uid_parser(list_genome_p)
-  list_genome_p = add_json_parser(list_genome_p)
-
-  list_workflows_p = list_sp.add_parser(
-    'workflows',
+  list_pipelines_p = list_sp.add_parser(
+    'pipelines',
     help='List available workflows.'
   )
-  list_workflows_p = add_common_args(list_workflows_p)
-  list_workflows_p = add_json_parser(list_workflows_p)
-
-  list_workflow_p = list_sp.add_parser(
-    'workflow',
-    help='Detail a workflow'
-  )
-  list_module_p = add_common_args(list_workflow_p)
-  list_module_p = add_uid_parser(list_workflow_p)
-  list_module_p = add_json_parser(list_workflow_p)
+  list_pipelines_p = add_common_args(list_pipelines_p)
+  list_pipelines_p = add_json_parser(list_pipelines_p)
 
   list_modules_p = list_sp.add_parser(
     'pipeline_modules',
@@ -840,14 +878,6 @@ def read_args():
   list_modules_p = add_common_args(list_modules_p)
   list_modules_p = add_uid_parser(list_modules_p)
   list_modules_p = add_json_parser(list_modules_p)
-
-  list_module_p = list_sp.add_parser(
-    'module',
-    help='Detail a module'
-  )
-  list_module_p = add_common_args(list_module_p)
-  list_module_p = add_uid_parser(list_module_p)
-  list_module_p = add_json_parser(list_module_p)
 
   parser.set_defaults(params=[],)
   args = parser.parse_args()
@@ -886,7 +916,7 @@ def _list_item(bp, data_type=None, uids=None, is_json=False):
     eprint('Invalid data type.')
     return
 
-  list_type = ['analysis', 'genome', 'sample', 'module', 'pipeline_modules']
+  list_type = ['analysis', 'genome', 'sample', 'module', 'pipeline_modules', 'pipeline']
   if data_type not in list_type:
     eprint('List data type - {} currently not supported.'.format(data_type))
     return

--- a/bin/basepair
+++ b/bin/basepair
@@ -228,16 +228,14 @@ def create_analysis(bp, args):
 def create_module(bp, args):
   '''Create module'''
   if not args.yaml:
-    eprint('ERROR: Yaml required.')
+    eprint('ERROR: Yaml file required.')
     return
   if len(args.yaml) != 1:
     eprint('Please provide only one yaml')
     return
-  data = {
-    'yamlpath': args.yaml[0]
-  }
+  yaml_path = args.yaml[0]
   if args.yaml[0].endswith('.yaml'):
-    bp.create_module(data)
+    bp.create_module({'yamlpath': yaml_path})
   else:
     eprint('Please provide yaml file only')
     return
@@ -245,16 +243,14 @@ def create_module(bp, args):
 def create_workflow(bp, args):
   '''Create workflow'''
   if not args.yaml:
-    eprint('ERROR: Yaml required.')
+    eprint('ERROR: Yaml file required.')
     return
   if len(args.yaml) != 1:
     eprint('Please provide only one yaml')
     return
-  data = {
-    'yamlpath': args.yaml[0]
-  }
+  yaml_path = args.yaml[0]
   if args.yaml[0].endswith('.yaml'):
-    bp.create_workflow(data)
+    bp.create_workflow({'yamlpath': yaml_path})
   else:
     eprint('Please provide yaml file only')
     return
@@ -397,33 +393,28 @@ def update_analysis(bp, analysis_id, keys, vals):
 def update_module(bp, args):
   '''Update module'''
   if not args.yaml:
-    eprint('ERROR: Yaml required.')
+    eprint('ERROR: Yaml file required.')
     return
   if len(args.yaml) != 1:
     eprint('Please provide only one yaml')
     return
-  data = {
-    'yamlpath': args.yaml[0]
-  }
+  yaml_path = args.yaml[0]
   if args.yaml[0].endswith('.yaml'):
-    bp.update_module(data)
+    bp.update_module({'yamlpath': yaml_path})
   else:
     eprint('Please provide yaml file only')
-
 
 def update_workflow(bp, args):
   '''Update workflow'''
   if not args.yaml:
-    eprint('ERROR: Yaml required.')
+    eprint('ERROR: Yaml file required.')
     return
   if len(args.yaml) != 1:
     eprint('Please provide only one yaml')
     return
-  data = {
-    'yamlpath': args.yaml[0]
-  }
+  yaml_path = args.yaml[0]
   if args.yaml[0].endswith('.yaml'):
-    bp.update_workflow(data)
+    bp.update_workflow({'yamlpath': yaml_path})
   else:
     eprint('Please provide yaml file only')
 

--- a/bin/basepair
+++ b/bin/basepair
@@ -236,7 +236,7 @@ def check_yaml(args):
     return False
   yaml_path = args.file[0]
   valid_extensions = ('.yaml', '.yml')
-  if yaml_path.endsWith(valid_extensions):
+  if yaml_path.endswith(valid_extensions):
     return True
   eprint('Please provide yaml file only')
   return False

--- a/bin/basepair
+++ b/bin/basepair
@@ -98,6 +98,10 @@ def main():
   if args.action == 'create':
     if args.create_type == 'project':
       create_project(bp, args)
+    if args.create_type == 'module':
+      create_module(bp, args)
+    if args.create_type == 'workflow':
+      create_workflow(bp, args)
 
     if args.create_type == 'sample':
 
@@ -116,12 +120,17 @@ def main():
       create_sample(bp, args)
     if args.create_type == 'analysis':
       create_analysis(bp, args)
-  elif args.action == 'updateProject':
-    update_project(bp, args)
-  elif args.action == 'updateSample':
-    update_sample(bp, args)
-  elif args.action == 'updateAnalysis':
-    update_analysis(bp, args.analysis, args.key, args.val)
+  elif args.action == 'update':
+    if args.update_type == 'analysis':
+      update_analysis(bp, args.analysis, args.key, args.val)
+    if args.update_type == 'project':
+      update_project(bp, args)
+    if args.update_type == 'sample':
+      update_sample(bp, args)
+    if args.update_type == 'module':
+      update_module(bp, args)
+    if args.update_type == 'workflow':
+      update_workflow(bp, args)
   elif args.action == 'download':
     if args.download_type == 'analysis':
       download_analysis(bp, args)
@@ -210,6 +219,32 @@ def create_analysis(bp, args):
     sample_ids=args.sample,
     workflow_id=args.workflow,
   )
+
+def create_module(bp, args):
+  '''Create module'''
+  if not args.yaml:
+    eprint('ERROR: Yaml required.')
+    return
+  data = {
+    'yamlpath': args.yaml
+  }
+  if args.yaml.endswith('.yaml'):
+    bp.create_module(data)
+  else:
+    eprint('Please provide yaml file only')
+
+def create_workflow(bp, args):
+  '''Create workflow'''
+  if not args.yaml:
+    eprint('ERROR: Yaml required.')
+    return
+  data = {
+    'yamlpath': args.yaml
+  }
+  if args.yaml.endswith('.yaml'):
+    bp.create_workflow(data)
+  else:
+    eprint('Please provide yaml file only')
 
 
 def download_analysis(bp, args):
@@ -347,6 +382,32 @@ def update_analysis(bp, analysis_id, keys, vals):
     return
   update_info(bp, kind='analysis', uid=analysis_id, keys=keys, vals=vals)
 
+def update_module(bp, args):
+  '''Update module'''
+  if not args.yaml:
+    eprint('ERROR: Yaml required.')
+    return
+  data = {
+    'yamlpath': args.yaml
+  }
+  if args.yaml.endswith('.yaml'):
+    bp.update_module(data)
+  else:
+    eprint('Please provide yaml file only')
+
+
+def update_workflow(bp, args):
+  '''Update workflow'''
+  if not args.yaml:
+    eprint('ERROR: Yaml required.')
+    return
+  data = {
+    'yamlpath': args.yaml
+  }
+  if args.yaml.endswith('.yaml'):
+    bp.update_workflow(data)
+  else:
+    eprint('Please provide yaml file only')
 
 def delete(bp, data_type, uid):
   '''Delete object'''
@@ -443,6 +504,16 @@ def add_tags_parser(parser):
   )
   return parser
 
+def add_yaml_parser(parser):
+  '''Add uid parser'''
+  parser.add_argument(
+    '-y',
+    '--yaml',
+    default=None,
+    required=True,
+    help='The filepath of YAML'
+  )
+  return parser
 
 def read_args():
   '''Read args'''
@@ -525,9 +596,34 @@ def read_args():
     help='Ignore validation warnings',
   )
 
+  # create module parser
+  create_module_p = create_sp.add_parser(
+    'module',
+    help='Create module.'
+  )
+  create_module_p = add_common_args(create_module_p)
+  create_module_p = add_yaml_parser(create_module_p)
+
+  # create workflow parser
+  create_workflow_p = create_sp.add_parser(
+    'workflow',
+    help='Create workflow.'
+  )
+  create_workflow_p = add_common_args(create_workflow_p)
+  create_workflow_p = add_yaml_parser(create_workflow_p)
+
+  # update parser
+  update_p = actions_p.add_parser(
+    'update',
+    help='Update analyses, samples, project.'
+  )
+  update_sp = update_p.add_subparsers(
+    help='Type of item to update',
+    dest='update_type'
+  )
   # update project parser
-  update_project_parser = actions_p.add_parser(
-    'updateProject',
+  update_project_parser = update_sp.add_parser(
+    'project',
     help='Update information associated with a project.'
   )
   update_project_parser = add_common_args(update_project_parser)
@@ -537,10 +633,9 @@ def read_args():
   update_project_parser.add_argument('--emails', default=[], nargs='+')
   update_project_parser.add_argument('--perm', choices=['admin', 'edit', 'view'], default='view')
   update_project_parser.add_argument('--name')
-
   # update sample parser
-  update_sample_parser = actions_p.add_parser(
-    'updateSample',
+  update_sample_parser = update_sp.add_parser(
+    'sample',
     help='Update information associated with a sample.'
   )
   update_sample_parser = add_common_args(update_sample_parser)
@@ -558,16 +653,31 @@ def read_args():
   )
   update_sample_parser.add_argument('--key', action='append')
   update_sample_parser.add_argument('--val', action='append')
-
   # update analysis parser
-  update_analysis_parser = actions_p.add_parser(
-    'updateAnalysis',
+  update_analysis_parser = update_sp.add_parser(
+    'analysis',
     help='Update information associated with an analysis.'
   )
   update_analysis_parser = add_common_args(update_analysis_parser)
   update_analysis_parser.add_argument('-a', '--analysis', help='Analysis id')
   update_analysis_parser.add_argument('--key', action='append')
   update_analysis_parser.add_argument('--val', action='append')
+
+  # update module parser
+  update_module_parser = update_sp.add_parser(
+    'module',
+    help='Update information associated with a module.'
+  )
+  update_module_parser = add_common_args(update_module_parser)
+  update_module_parser = add_yaml_parser(update_module_parser)
+
+  # update workflow parser
+  update_workflow_parser = update_sp.add_parser(
+    'workflow',
+    help='Update information associated with a workflow.'
+  )
+  update_workflow_parser = add_common_args(update_workflow_parser)
+  update_workflow_parser = add_yaml_parser(update_workflow_parser)
 
   # download parsers
   download_p = actions_p.add_parser('download', help='Download items.')


### PR DESCRIPTION
This PR has the following new features to the CLI -

1. User should be able to create and update the module and pipeline from .yaml or .yml file

create module --file test-module.yaml
update module --file test-module.yaml
create pipeline --file test-pipeline.yaml
update pipeline --file test-pipeline.yaml

2. User should be able to create Module or Pipeline with —force argument - 

When id is provided for create command and a module or pipeline exists
1 .If  --force is present in command then warn update the module or pipeline with that id
2. If  --force is not present then tell the user that the module or pipeline already exists, do they want to overwrite it? take yes or no (y/n) as an answer.

There will be certain Improvements -

Now User should be able to delete the datatype using the delete command -
delete module
delete pipeline
delete analysis
delete sample

For getting a datatype using one or more uid. Now user should be able to use -
get analysis
get sample
get module -u 147 47 (example)
get pipeline
get genome

Now user should be able to use keyword pipeline instead of workflow
create pipeline
update pipeline
delete pipeline
list pipelines
get pipeline




Related Tickets - 
1.https://app.asana.com/0/1201368373933132/1201541277176933
2.https://app.asana.com/0/1201368373933132/1201541277176931
3.https://app.asana.com/0/1201368373933132/1201541277176929
4.https://app.asana.com/0/1201368373933132/1201589980257994
5.https://app.asana.com/0/1201368373933132/1201589980257997
6.https://app.asana.com/0/1201368373933132/1201591800876085
7.https://app.asana.com/0/1201368373933132/1201591800876085