### PR TITLE
Improvement delete get pipeline feedback

### DIFF
--- a/basepair/api.py
+++ b/basepair/api.py
@@ -192,7 +192,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
 
   def delete_analysis(self, uid):
     '''Delete method'''
-    return (Analysis(self.conf.get('api'))).delete(uid)
+    info = (Analysis(self.conf.get('api'))).delete(uid)
+    if info.get('error'):
+      eprint('error: deleting {}, msg: {}'.format(uid, info.get('msg')))
+      return None
+
+    if self.verbose:
+      eprint('deleted analysis', uid)
+    return info
 
   def download_analysis(self, uid, outdir='.', tagkind=None, tags=None):
     '''
@@ -471,7 +478,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   
   def delete_module(self, uid):
     '''Delete method'''
-    return (Module(self.conf.get('api'))).delete(uid)
+    info = (Module(self.conf.get('api'))).delete(uid)
+    if info.get('error'):
+      eprint('error: deleting {}, msg: {}'.format(uid, info.get('msg')))
+      return None
+
+    if self.verbose:
+      eprint('deleted module', uid)
+    return info
 
   ################################################################################################
   ### PIPELINE / WORKFLOW ########################################################################
@@ -538,7 +552,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
 
   def delete_pipeline(self, uid):
     '''Delete method'''
-    return (Pipeline(self.conf.get('api'))).delete(uid)
+    info = (Pipeline(self.conf.get('api'))).delete(uid)
+    if info.get('error'):
+      eprint('error: deleting {}, msg: {}'.format(uid, info.get('msg')))
+      return None
+
+    if self.verbose:
+      eprint('deleted pipeline', uid)
+    return info
 
   ################################################################################################
   ### PROJECT ####################################################################################
@@ -1337,7 +1358,6 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     list_methods = {
       'analyses': 'get_analyses',
       'genomes': 'get_genomes',
-      'module': 'get_module',
       'pipeline_modules':'get_pipeline_modules',
       'samples': 'get_samples',
       'pipelines': 'get_pipelines'

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -470,7 +470,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     return None
   
   def get_module(self, uid):
-    '''Get resource'''
+    '''Get module resource'''
     return (Module(self.conf.get('api'))).get(
         uid,
         cache='{}/json/module.{}.json'.format(self.scratch, uid) if self.use_cache else False,
@@ -491,6 +491,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
   ### PIPELINE / WORKFLOW ########################################################################
   ################################################################################################
   def create_pipeline(self,data):
+    '''create pipeline from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()
@@ -510,6 +511,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     return None
 
   def update_pipeline(self,data):
+    '''update pipeline from yaml'''
     path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -445,9 +445,7 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
 
   def update_module(self,data):
     '''update module from yaml'''
-    path = os.path.abspath(os.path.expanduser(
-          os.path.expandvars(data['yamlpath'])
-      ))
+    path = os.path.abspath(os.path.expanduser(os.path.expandvars(data['yamlpath'])))
     with open(path,'r') as fp:
       yaml_string = fp.read()
     yaml_data = yaml.load(yaml_string,Loader=yaml.FullLoader)

--- a/basepair/helpers/nice_print.py
+++ b/basepair/helpers/nice_print.py
@@ -192,7 +192,7 @@ class NicePrint:
     ]))
 
   @staticmethod
-  def workflows(data):
+  def pipelines(data):
     '''Print pipelines'''
     to_print = [
       [
@@ -212,7 +212,7 @@ class NicePrint:
     ]))
 
   @staticmethod
-  def workflow(data):
+  def pipeline(data):
     '''Print pipeline'''
     to_print = [
       [

--- a/bin/basepair
+++ b/bin/basepair
@@ -151,12 +151,8 @@ def main():
       bp.print_data(data_type='analyses', is_json=args.json, project=args.project)
     elif args.list_type == 'genomes':
       bp.print_data(data_type='genomes', is_json=args.json)
-    elif args.list_type == 'sample':
-      _list_item(bp, data_type='sample', uids=args.uid, is_json=args.json)
     elif args.list_type == 'pipeline_modules':
       _list_item(bp, data_type='pipeline_modules', uids=args.uid, is_json=args.json)
-    elif args.list_type == 'module':
-      _list_item(bp, data_type='module', uids=args.uid, is_json=args.json)
     elif args.list_type == 'samples':
       bp.print_data(data_type='samples', is_json=args.json, project=args.project)
     elif args.list_type == 'pipelines':
@@ -751,7 +747,7 @@ def read_args():
   )
   delete_sp = delete_parser.add_subparsers(
     dest='delete_type',
-    help='Type of data to delete. Options: sample, analysis, workflow, module',
+    help='Type of data to delete. Options: sample, analysis, pipeline, module',
   )
   delete_analysis_p = delete_sp.add_parser(
     'analysis',


### PR DESCRIPTION
This PR will provide these improvements.

There will be Improvement in Delete Component -

1. Now User should be able to delete the datatype using the delete command -
delete module
delete pipeline
delete analysis
delete sample

2. For getting a datatype using one or more uid. Now user should be able to use -
get analysis
get sample
get module -u 147 47 (example)
get pipeline
get genome 

3. Now user should be able to use keyword pipeline instead of workflow 
create pipeline
update pipeline
delete pipeline
list pipelines
get pipeline 
 
Related Ticket - 
https://app.asana.com/0/1201368373933132/1201589980257994