### PR TITLE
Improvement-dirname-suffix

### DIFF
--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -10,7 +10,7 @@ from .utils import colors
 from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module, Pipeline, Project, Sample, Upload, User
 
 __title__ = 'basepair'
-__version__ = '2.0.4'
+__version__ = '2.0.5'
 __copyright__ = 'Copyright [2017] - [2022] Basepair INC'
 
 

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -965,13 +965,17 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     try:
       # get the download directory
       prefix = self.scratch
+      suffix = 'basepair/'      
       if file_type == 'analyses':
         analyses_type_path = os.path.dirname(filekey)
         analyses_type = os.path.basename(analyses_type_path)
       if dirname:
         prefix = dirname if dirname.startswith('/') else os.path.join(self.scratch, dirname)
-      suffix = 'basepair/'
-      if file_type == 'analyses' and uid:
+        suffix = ''
+
+      if file_type == 'analyses' and uid and dirname:
+        suffix = ''
+      elif file_type == 'analyses' and uid:
         suffix = 'basepair/{}/{}/{}'.format(file_type, uid, analyses_type)
       elif file_type and uid:
         suffix = 'basepair/{}/{}'.format(file_type, uid)

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -972,9 +972,6 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       if dirname:
         prefix = dirname if dirname.startswith('/') else os.path.join(self.scratch, dirname)
         suffix = ''
-
-      if file_type == 'analyses' and uid and dirname:
-        suffix = ''
       elif file_type == 'analyses' and uid:
         suffix = 'basepair/{}/{}/{}'.format(file_type, uid, analyses_type)
       elif file_type and uid:


### PR DESCRIPTION
The basepair api method download file has suffix & prefix added in the version 2.0.4. When this method is used along with dirname, the suffix variable of the method creates a "basepair" named directory in the cwd, inside which the downloaded files are stored, because of this many bioinfo codes are breaking, since the files are not accessible from cwd.

Solution to the above issue: If dirname is used while calling the method, there wont be any suffix added to the downloadable path but the cwd, This is stop breaking of bioinfo codes.