### PR TITLE
Web 205 cli command analysis download command is not working

### DIFF
--- a/basepair/api.py
+++ b/basepair/api.py
@@ -23,6 +23,7 @@ from __future__ import print_function
 import os
 import sys
 import json
+import requests
 import subprocess
 from subprocess import CalledProcessError
 import time
@@ -1147,10 +1148,22 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     if params:
       for arg, val in params.items():
         _params += ' {} "{}"'.format(arg, val)
-
     storage_cfg = self.configuration.get_user_storage()
+    # check user permission (over log file/sample/analysis) (is this the right place to put the permission)
+    # if has permission
+    # then get the pre_signed_url(src) should we hit the api?
+    # stream_download(url, dest) 
     credential = self.configuration.get_cli_credentials_from(storage_cfg)
     return '{}aws s3 cp "{}" "{}" {}'.format(credential, src, dest, _params)
+
+  def stream_download(self, url, dest, chunk_size=8192):
+    try: 
+      response = requests.get(url, stream=True)
+      with open(dest, 'wb') as fd:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+          fd.write(chunk)
+    except Exception as error:
+      print(error)
 
   def get_expression_count_file(self, sample, features='transcripts', multiple=False):
     '''Get expression count text file - for RNA-Seq'''

--- a/basepair/api.py
+++ b/basepair/api.py
@@ -929,13 +929,14 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
     dest: {str} Directory or file path where file will be downloaded to [Required]
     src:  {str} File path on AWS S3, not including the bucket           [Required]
     '''
-    storage_cfg = self.configuration.get_user_storage()
-    if not src.startswith('s3://'):
-      src = 's3://{}/{}'.format(storage_cfg.get('bucket'), src)
-    cmd = self.get_copy_cmd(src, dest)
+    response = (File(self.conf.get('api'))).get_presigned_url(key=src)
+    if response.get('error'):
+      msg = f'Error: {response.get("error") or "You do not have permission to download the file"}'
+      eprint(msg)
+      return False
     if self.verbose:
       eprint('copying from s3 bucket to {}'.format(' ./'+dest.split('/')[-1]))
-    return self._execute_command(cmd=cmd, retry=3)
+    return self.stream_download(response.get('signed_url'))
 
   def copy_file_to_s3(self, src, dest, params=None):
     '''Low level function to copy a file to cloud from disk'''
@@ -1003,6 +1004,16 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       return filepath
     except Exception:# pylint: disable=bare-except
       return False
+
+  def stream_download(self, url, dest, chunk_size=8192):
+    '''Method to download the files'''
+    try:
+      response = requests.get(url, stream=True)
+      with open(dest, 'wb') as fd:
+        for chunk in response.iter_content(chunk_size=chunk_size):
+          fd.write(chunk)
+    except Exception as error:
+      print(error)
 
   def download_raw_files(self, sample, file_type=None, outdir=None, uid=None,):
     '''

--- a/basepair/infra/webapp/file.py
+++ b/basepair/infra/webapp/file.py
@@ -1,5 +1,9 @@
 '''File webapp api wrapper'''
 
+# General imports
+import requests
+import json
+
 # App imports
 from .abstract import Abstract
 
@@ -8,3 +12,22 @@ class File(Abstract):
   def __init__(self, cfg):
     super(File, self).__init__(cfg)
     self.endpoint += 'files/'
+
+  def get_presigned_url(self, key):
+    '''Method to call the http request to sign the url'''
+    payload = {'key': key}
+    return self._file_post_request('get_presigned_url', payload)
+
+  def _file_post_request(self, route, payload):
+    '''Call the appropriate endpoint'''
+    try:
+      response = requests.post(
+        f'{self.endpoint}{route}',
+        data=json.dumps(payload),
+        params=self.payload,
+        verify=True,
+        headers={'content-type': 'application/json'}
+      )
+      return self._parse_response(response)
+    except Exception as error:
+      return {'error': True, 'msg': error}


### PR DESCRIPTION
Story: https://basepairtech.atlassian.net/browse/WEB-205

## Need for the PR
When using the CLI the users are not able to download files/samples that have been shared to them. This is because we are using the directory structure based permission policy when doing `aws cp source destination`. 

### Solution
Instead of relying on the permission set by the policy, we will check the permission using the permission methods defined in https://github.com/basepair/webapp/pull/1588/files#diff-f9795f315b679b5b1e2ced76b2291763cfdf9f48fba6dcd284a20c1e258209d4 to check if the user has access (or has been granted the permission by the owner). 

### Approach
1. whenever a request to dowload a file is created
2. check the permission making the api call to webapp
3. if permission exists, generate the pre-signed url.
4. using that presigned url download the files; instead of using `aws cp` we will be using `requests` library to dowload 

dependent pr: 
https://github.com/basepair/webapp/pull/1588