### PR TITLE
BugFix: Remove protocol for resource uri method

### DIFF
--- a/basepair/infra/webapp/abstract.py
+++ b/basepair/infra/webapp/abstract.py
@@ -99,8 +99,7 @@ class Abstract(object):
 
   def resource_uri(self, obj_id):
     '''Generate resource uri from obj id'''
-    path = self.endpoint.replace(self.host, '')
-    return '{}{}'.format(path, obj_id)
+    return '{}{}'.format(self.pathname, obj_id)
 
   def resource_url(self, obj_id):
     '''Generate resource uri from obj id'''
@@ -123,6 +122,10 @@ class Abstract(object):
     except requests.exceptions.RequestException as error:
       eprint('ERROR: {}'.format(error))
       return {'error': True, 'msg': error}
+
+  @property
+  def pathname(self):
+    return self.endpoint.replace(f"{self.protocol}://", '').replace(self.host, '')
 
   @staticmethod
   def _get_from_cache(cache):

--- a/basepair/infra/webapp/abstract.py
+++ b/basepair/infra/webapp/abstract.py
@@ -14,6 +14,7 @@ class Abstract(object):
   '''Webapp abastract class'''
   def __init__(self, cfg):
     protocol = 'https' if cfg.get('ssl', True) else 'http'
+    self.protocol = protocol
     self.host = cfg.get('host')
     self.endpoint = "{}://{}{}".format(protocol, self.host, cfg.get('prefix'))
     self.payload = {


### PR DESCRIPTION
### Why is this change needed?
Currently the `Abstract.resource_uri` method is returning the protocol in the uri e.g. for sample id 5420 it will return `https:///api/v2/samples/5420` where as we should return just the resource uri `/api/v2/samples/5420`

### How does this PR address the problem?
This PR adds a derived property to the class that will replace the protocol and the host in the endpoint to return the correct uri.