### PR TITLE
Refactor-Step-04-Moving-AnalysisLog-To-Basepair-Lib

### DIFF
--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/basepair/modules/analysis_log/__init__.py
+++ b/basepair/modules/analysis_log/__init__.py
@@ -1,4 +1,4 @@
 '''Log module'''
-from .log import Log
+from .abstract import Abstract
 from .analysis import AnalysisLog
 from .infra import InfraLog

--- a/basepair/modules/analysis_log/__init__.py
+++ b/basepair/modules/analysis_log/__init__.py
@@ -1,0 +1,4 @@
+'''Log module'''
+from .log import Log
+from .analysis import AnalysisLog
+from .infra import InfraLog

--- a/basepair/modules/analysis_log/abstract.py
+++ b/basepair/modules/analysis_log/abstract.py
@@ -8,8 +8,8 @@ from datetime import datetime
 # Libs imports
 from basepair.infra.webapp import Analysis
 
-class Log:
-  '''Log class'''
+class Abstract:
+  '''Abstract class'''
   def __init__(self, config=None, analysis_id=None):
     self.analysis_id = analysis_id
     self.config = config

--- a/basepair/modules/analysis_log/analysis.py
+++ b/basepair/modules/analysis_log/analysis.py
@@ -1,0 +1,61 @@
+'''Analysis log wrapper'''
+
+# General imports
+import sys
+import os
+
+# Libs imports
+from basepair.infra.webapp import Analysis
+
+# App imports
+from .log import Log
+
+
+class AnalysisLog(Log):
+  '''Analysis log class'''
+  def __init__(self, analysis_id=None, config=None, kind=None, node_key=None):
+    super().__init__(config, analysis_id)
+    self.kind = kind
+    self.node_key = node_key
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': {
+        'bio': {
+          self.node_key: {
+            self.kind: {
+              **self.log
+            }
+          }
+        }
+      }
+    }
+
+  def update_node(self, cmd=None, status=None, time_taken=None):
+    '''Set node cmd, status'''
+    node_data = {
+      'status': status,
+      'time_taken': time_taken
+    }
+
+    if cmd:
+      node_data['commands'] = cmd
+    data = {
+      'id': self.analysis_id,
+      'log': {
+        'bio': {
+          self.node_key: node_data
+        }
+      }
+    }
+
+    try:
+      response = (Analysis(self.config.get('api'))).save_log(data)
+      if response.get('error'):
+        print('Error updating analysis node status')
+        return
+      print('Analysis node status updated')
+    except Exception as error: #pylint: disable=broad-except
+      print(f'ERROR: Updating analysis node status: {str(error)}')

--- a/basepair/modules/analysis_log/analysis.py
+++ b/basepair/modules/analysis_log/analysis.py
@@ -8,10 +8,10 @@ import os
 from basepair.infra.webapp import Analysis
 
 # App imports
-from .log import Log
+from .abstract import Abstract
 
 
-class AnalysisLog(Log):
+class AnalysisLog(Abstract):
   '''Analysis log class'''
   def __init__(self, analysis_id=None, config=None, kind=None, node_key=None):
     super().__init__(config, analysis_id)

--- a/basepair/modules/analysis_log/infra.py
+++ b/basepair/modules/analysis_log/infra.py
@@ -1,0 +1,22 @@
+'''Infra log wrapper'''
+
+# General imports
+import sys
+import os
+
+# App imports
+from .log import Log
+
+class InfraLog(Log): #pylint: disable=too-few-public-methods
+  '''Infra log class'''
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': {
+        'infra': {
+          **self.log
+        }
+      }
+    }

--- a/basepair/modules/analysis_log/infra.py
+++ b/basepair/modules/analysis_log/infra.py
@@ -5,9 +5,9 @@ import sys
 import os
 
 # App imports
-from .log import Log
+from .abstract import Abstract
 
-class InfraLog(Log): #pylint: disable=too-few-public-methods
+class InfraLog(Abstract): #pylint: disable=too-few-public-methods
   '''Infra log class'''
 
   def get_data(self):

--- a/basepair/modules/analysis_log/log.py
+++ b/basepair/modules/analysis_log/log.py
@@ -1,0 +1,67 @@
+'''log Wrappers'''
+
+# General imports
+import os
+import sys
+from datetime import datetime
+
+# Libs imports
+from basepair.infra.webapp import Analysis
+
+class Log:
+  '''Log class'''
+  def __init__(self, config=None, analysis_id=None):
+    self.analysis_id = analysis_id
+    self.config = config
+    self.log = {
+      'error': [],
+      'info': [],
+      'warning': []
+    }
+
+  def clear(self):
+    '''Clear logs'''
+    self.log = {
+      'error': [],
+      'info': [],
+      'warning': []
+    }
+
+  def error(self, msg, display_in_report_view=False):
+    '''log errors'''
+    self._log(field='error', msg=msg, display_in_report_view=display_in_report_view)
+
+  def info(self, msg, display_in_report_view=False):
+    '''log info'''
+    self._log(field='info', msg=msg, display_in_report_view=display_in_report_view)
+
+  def flush(self):
+    '''Save log in db'''
+    data = self.get_data()
+    response = (Analysis(self.config.get('api'))).save_log(data)
+    if response.get('error'):
+      print('Error saving analysis log')
+      return
+    print('Analysis log saved')
+    self.clear()
+
+  def warning(self, msg, display_in_report_view=False):
+    '''log warning'''
+    self._log(field='warning', msg=msg, display_in_report_view=display_in_report_view)
+
+  def _log(self, field='', msg=None, display_in_report_view=False):
+    '''log messages'''
+    msg = {
+      'datetime': str(datetime.now()),
+      'msg': msg,
+    }
+    if display_in_report_view:
+      msg['display_in_report_view'] = True
+    self.log.get(field).append(msg)
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': self.log
+    }

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ packages = [
     'basepair.modules',
     'basepair.modules.alert',
     'basepair.modules.alert.drivers',
+    'basepair.modules.analysis_log',
     'basepair.modules.aws',
     'basepair.modules.aws.handler',
     'basepair.modules.identity',


### PR DESCRIPTION
### Motivation
Analysis log is being use in the worker but also in the bioinfo script, for this reason we need to place the source code in basepair lib.

### How we achieve this
We just move the code to be a importable module from basepair lib.
