### PR TITLE
BugFix-Referencing-Before-Assignment

### DIFF
--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 __copyright__ = 'Copyright [2017] - [2022] Basepair INC'
 
 

--- a/basepair/modules/aws/s3.py
+++ b/basepair/modules/aws/s3.py
@@ -79,7 +79,7 @@ class S3(Service):
     # if there are invalid uris we return a warning
     if uri_list.get('not_valid'):
       response = self.get_log_msg({
-        'exception': error,
+        'exception': 'Not valid URI.',
         'msg': f"Not valid uris provided for deletion.\n{json.dumps(uri_list.get('not_valid'), indent=2)}",
         'msg_type': 'warning',
       })


### PR DESCRIPTION
### Motivation
When we call S3 bulk deletion we get an error because we reference a variable before declaring it.

### How we achieve this
We replace the variable reference with a constant string.