### PR TITLE
GitHub action to manually trigger packaging and publish

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -38,6 +38,7 @@ jobs:
       run: |
         twine check dist/*
       continue-on-error: false
+
     # Step 5: Upload the package to PyPI
     - name: Upload package to PyPI
       env:

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,10 +1,54 @@
-name: Build and Publish Python Package
+name: Publish Python Package
 
+# Trigger manually using workflow_dispatch
 on:
   workflow_dispatch:
+    inputs:
+      package_name:
+        description: 'Name of the package'
+        required: true
 
 jobs:
-  package:
-    runs-on: ubuntu:latest
+  build-and-publish:
+    runs-on: ubuntu-latest
+
     steps:
-      - run: echo "We did the thing"
+    # Step 1: Checkout the repository
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    # Step 2: Set up Python environment
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    # Step 3: Upgrade pip and install dependencies
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    # Step 4: Build the package
+    - name: Build the package
+      run: |
+        python setup.py sdist bdist_wheel
+
+    - name: Check the package with twine
+      run: |
+        twine check dist/*
+      continue-on-error: false
+    # Step 5: Upload the package to PyPI
+    - name: Upload package to PyPI
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m twine upload dist/*
+
+    # Step 6: Upload built package as an artifact
+    - name: Upload package as artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package
+        path: dist/*

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,10 +3,6 @@ name: Publish Python Package
 # Trigger manually using workflow_dispatch
 on:
   workflow_dispatch:
-    inputs:
-      package_name:
-        description: 'Name of the package'
-        required: true
 
 jobs:
   build-and-publish:

--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,5 @@ docs/_build/
 target/
 .idea
 
-# for pypi publication
+# for local testing of github actions using act
 .secrets

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 # PyBuilder
 target/
 .idea
+
+# for pypi publication
+.secrets


### PR DESCRIPTION
## What does this PR do? 
- [x] Use GitHub action to package and publish the `basepair-python` lib. 
- [x] Add `.secrets` to `.gitignore` to test the github action locally with https://github.com/nektos/act