### PR TITLE
Subnet and Availability zone check

### DIFF
--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.1.5rc1'
+__version__ = '2.1.6'
 __copyright__ = 'Copyright [2017] - [2022] Basepair INC'
 
 

--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.1.5'
+__version__ = '2.1.5a'
 __copyright__ = 'Copyright [2017] - [2022] Basepair INC'
 
 

--- a/basepair/__init__.py
+++ b/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.1.5a'
+__version__ = '2.1.5rc1'
 __copyright__ = 'Copyright [2017] - [2022] Basepair INC'
 
 

--- a/basepair/modules/aws/ec2.py
+++ b/basepair/modules/aws/ec2.py
@@ -158,10 +158,18 @@ class EC2(Service):
       specification['SubnetId'] = settings.get('subnet_id')
     elif availability_zone:
       specification['Placement'] = {'AvailabilityZone': availability_zone}
-      for subnet_id in settings.get('subnet_ids') or []:
-        subnet = self.resource.Subnet(subnet_id)
-        if subnet.availability_zone == availability_zone:
-          specification['SubnetId'] = subnet_id
+      subnet_ids = settings.get('subnet_ids')
+      if subnet_ids:
+        for subnet_id in subnet_ids:
+          subnet = self.resource.Subnet(subnet_id)
+          if subnet.availability_zone == availability_zone:
+            specification['SubnetId'] = subnet_id
+            break
+        else:
+          return self.get_log_msg({
+            'exception': None,
+            'msg': 'No subnet found in the availability zone.',
+          })
 
     price = settings.get('spot_price') or ''
     try:


### PR DESCRIPTION
If `subnet_ids` is provided in config, then select a subnet for given `availability_zone` or else throw error.
If `subnet_ids` is not provided, then let AWS select a random subnet for given `availability_zone`.