### PR TITLE
Feature-Moving-AnalysisLog

### DIFF
--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.0'
+__version__ = '2.2.1'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/modules/analysis_log/__init__.py
+++ b/app/basepair/modules/analysis_log/__init__.py
@@ -1,0 +1,4 @@
+'''Log module'''
+from .abstract import Abstract
+from .analysis import AnalysisLog
+from .infra import InfraLog

--- a/app/basepair/modules/analysis_log/abstract.py
+++ b/app/basepair/modules/analysis_log/abstract.py
@@ -1,0 +1,67 @@
+'''log Wrappers'''
+
+# General imports
+import os
+import sys
+from datetime import datetime
+
+# Libs imports
+from basepair.infra.webapp import Analysis
+
+class Abstract:
+  '''Abstract class'''
+  def __init__(self, config=None, analysis_id=None):
+    self.analysis_id = analysis_id
+    self.config = config
+    self.log = {
+      'error': [],
+      'info': [],
+      'warning': []
+    }
+
+  def clear(self):
+    '''Clear logs'''
+    self.log = {
+      'error': [],
+      'info': [],
+      'warning': []
+    }
+
+  def error(self, msg, display_in_report_view=False):
+    '''log errors'''
+    self._log(field='error', msg=msg, display_in_report_view=display_in_report_view)
+
+  def info(self, msg, display_in_report_view=False):
+    '''log info'''
+    self._log(field='info', msg=msg, display_in_report_view=display_in_report_view)
+
+  def flush(self):
+    '''Save log in db'''
+    data = self.get_data()
+    response = (Analysis(self.config.get('api'))).save_log(data)
+    if response.get('error'):
+      print('Error saving analysis log')
+      return
+    print('Analysis log saved')
+    self.clear()
+
+  def warning(self, msg, display_in_report_view=False):
+    '''log warning'''
+    self._log(field='warning', msg=msg, display_in_report_view=display_in_report_view)
+
+  def _log(self, field='', msg=None, display_in_report_view=False):
+    '''log messages'''
+    msg = {
+      'datetime': str(datetime.now()),
+      'msg': msg,
+    }
+    if display_in_report_view:
+      msg['display_in_report_view'] = True
+    self.log.get(field).append(msg)
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': self.log
+    }

--- a/app/basepair/modules/analysis_log/analysis.py
+++ b/app/basepair/modules/analysis_log/analysis.py
@@ -1,0 +1,61 @@
+'''Analysis log wrapper'''
+
+# General imports
+import sys
+import os
+
+# Libs imports
+from basepair.infra.webapp import Analysis
+
+# App imports
+from .abstract import Abstract
+
+
+class AnalysisLog(Abstract):
+  '''Analysis log class'''
+  def __init__(self, analysis_id=None, config=None, kind=None, node_key=None):
+    super().__init__(config, analysis_id)
+    self.kind = kind
+    self.node_key = node_key
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': {
+        'bio': {
+          self.node_key: {
+            self.kind: {
+              **self.log
+            }
+          }
+        }
+      }
+    }
+
+  def update_node(self, cmd=None, status=None, time_taken=None):
+    '''Set node cmd, status'''
+    node_data = {
+      'status': status,
+      'time_taken': time_taken
+    }
+
+    if cmd:
+      node_data['commands'] = cmd
+    data = {
+      'id': self.analysis_id,
+      'log': {
+        'bio': {
+          self.node_key: node_data
+        }
+      }
+    }
+
+    try:
+      response = (Analysis(self.config.get('api'))).save_log(data)
+      if response.get('error'):
+        print('Error updating analysis node status')
+        return
+      print('Analysis node status updated')
+    except Exception as error: #pylint: disable=broad-except
+      print(f'ERROR: Updating analysis node status: {str(error)}')

--- a/app/basepair/modules/analysis_log/infra.py
+++ b/app/basepair/modules/analysis_log/infra.py
@@ -1,0 +1,22 @@
+'''Infra log wrapper'''
+
+# General imports
+import sys
+import os
+
+# App imports
+from .abstract import Abstract
+
+class InfraLog(Abstract): #pylint: disable=too-few-public-methods
+  '''Infra log class'''
+
+  def get_data(self):
+    '''Set log data'''
+    return {
+      'id': self.analysis_id,
+      'log': {
+        'infra': {
+          **self.log
+        }
+      }
+    }

--- a/app/setup.py
+++ b/app/setup.py
@@ -21,6 +21,7 @@ packages = [
     'basepair.modules',
     'basepair.modules.alert',
     'basepair.modules.alert.drivers',
+    'basepair.modules.analysis_log',
     'basepair.modules.aws',
     'basepair.modules.aws.handler',
     'basepair.modules.identity',


### PR DESCRIPTION
## Motivation
We want to move the Analysis log module to Basepair lib so then it can be available in multiple applications, for instance, worker and bio-validations.
This is needed to add post validation to pipelines that use the new dockerized worker.

## How this PR address the changes?
We just add the required module and expose it to be imported like `from basepair.modules.analysis_log import AnalysisLog`.