### PR TITLE
HotFix-Adding-Missing-Policy-Method

### DIFF
--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.3'
+__version__ = '2.2.4'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/modules/aws/policy.py
+++ b/app/basepair/modules/aws/policy.py
@@ -355,3 +355,15 @@ class Policy: # pylint: disable=too-few-public-methods
       }],
       'Version': '2012-10-17'
     }
+
+  @staticmethod
+  def sts_get_caller_id():
+    '''Get caller ID'''
+    return {
+      'Statement': [{
+        'Effect': 'Allow',
+        'Action': ['sts:GetCallerIdentity'],
+        'Resource': '*'
+      }],
+      'Version': '2012-10-17'
+    }


### PR DESCRIPTION
## Motivation:
The Policy method `sts_get_caller_id` being use in Pinda karyomap (kMap) was deleted so we are not able to update basepair python library in related environments.
This method is also needed by Pinda partiseq.

## How this PR address the fix?
We just re add the method that was removed.