### PR TITLE
HotFix-WEBAPP-760-Moving-BPConfig-To-Secrets

### DIFF
--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.6b'
+__version__ = '2.2.6'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.6beta'
+__version__ = '2.2.6b'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.5'
+__version__ = '2.2.6beta'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/modules/aws/sm.py
+++ b/app/basepair/modules/aws/sm.py
@@ -55,3 +55,23 @@ class SM(Service): # pylint: disable=too-few-public-methods
         json_content = json.dumps({'SecretString': secret})
         file.write(json_content)
     return secret
+
+  def put(self, secret_id, value, tags=None):
+    '''Set value to secret key'''
+    try:
+      args = {
+        "Name": secret_id,
+        "SecretString": value,
+      }
+      if tags:
+        args["Tags"] = tags
+      response = self.client.create_secret(**args)
+    except ClientError as error:
+      response = self.get_log_msg({
+        'exception': error,
+        'msg': f'Not able to get secret with id {secret_id}.',
+      })
+      if ExceptionHandler.is_throttled_error(exception=error):
+        raise error
+    return response
+


### PR DESCRIPTION
## Motivation
We are sending many secrets through the user data when we initialise ec2 for analysis. This cause one know issue related with large user data making the EC2 request to be denied by AWS.
The other issues are related with security because the secrets get expose in logs and in the user data.

## How this PR implement the fix?
We move the secrets to aws secret manager so we only use the user data to retrieve and delete the secret reducing the amount of data we put in the user data.

## Requires
- https://github.com/basepair/infra/pull/55
- https://github.com/basepair/webapp/pull/2258
- https://github.com/basepair/connected-cloud-cdk/pull/6

## Todo:
- [ ] Test common setup.
- [ ] Test cross aws setup.