### PR TITLE
HotFix-Delete-Secrets-When-Terminate-Instance-EC2-Driver

### DIFF
--- a/app/.pylintrc
+++ b/app/.pylintrc
@@ -18,8 +18,7 @@ ignore-patterns=
 init-hook=
   import sys
   import os
-  from pylint.config import find_pylintrc;
-  sys.path.append(os.path.dirname(find_pylintrc()))
+  sys.path.append("/home/app")
 
 # Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
 # number of processors available to use.
@@ -64,85 +63,15 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=print-statement,
-        parameter-unpacking,
-        unpacking-in-except,
-        old-raise-syntax,
-        backtick,
-        long-suffix,
-        old-ne-operator,
-        old-octal-literal,
-        import-star-module-level,
-        non-ascii-bytes-literal,
-        raw-checker-failed,
+disable=raw-checker-failed,
         bad-inline-option,
         locally-disabled,
         file-ignored,
         suppressed-message,
         useless-suppression,
         deprecated-pragma,
-        use-symbolic-message-instead,
-        apply-builtin,
-        basestring-builtin,
-        buffer-builtin,
-        cmp-builtin,
-        coerce-builtin,
-        execfile-builtin,
-        file-builtin,
-        long-builtin,
-        raw_input-builtin,
-        reduce-builtin,
-        standarderror-builtin,
-        unicode-builtin,
-        xrange-builtin,
-        coerce-method,
-        delslice-method,
-        getslice-method,
-        setslice-method,
-        no-absolute-import,
-        old-division,
-        dict-iter-method,
-        dict-view-method,
-        next-method-called,
-        metaclass-assignment,
-        indexing-exception,
-        raising-string,
-        reload-builtin,
-        oct-method,
-        hex-method,
-        nonzero-method,
-        cmp-method,
-        input-builtin,
-        round-builtin,
-        intern-builtin,
-        unichr-builtin,
-        map-builtin-not-iterating,
-        zip-builtin-not-iterating,
-        range-builtin-not-iterating,
-        filter-builtin-not-iterating,
-        using-cmp-argument,
-        eq-without-hash,
-        div-method,
-        idiv-method,
-        rdiv-method,
-        exception-message-attribute,
-        invalid-str-codec,
-        sys-max-int,
-        bad-python3-import,
-        deprecated-string-function,
-        deprecated-str-translate-call,
-        deprecated-itertools-function,
-        deprecated-types-field,
-        next-method-defined,
-        dict-items-not-iterating,
-        dict-keys-not-iterating,
-        dict-values-not-iterating,
-        deprecated-operator-function,
-        deprecated-urllib-function,
-        xreadlines-attribute,
-        deprecated-sys-function,
-        exception-escape,
-        comprehension-escape
+        use-symbolic-message-instead
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -318,7 +247,7 @@ expected-line-ending-format=
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$
 
 # Number of spaces of indent required inside a hanging or continued line.
-indent-after-paren=2
+indent-after-paren=1
 
 # String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
 # tab).
@@ -329,13 +258,6 @@ max-line-length=150
 
 # Maximum number of lines in a module.
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
@@ -570,5 +492,5 @@ min-public-methods=2
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception

--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.7beta'
+__version__ = '2.2.7'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.6'
+__version__ = '2.2.7beta'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/modules/aws/sm.py
+++ b/app/basepair/modules/aws/sm.py
@@ -1,4 +1,4 @@
-'''AWS SM Wrappers'''
+"""AWS SM Wrappers"""
 
 # General import
 import json
@@ -13,81 +13,90 @@ from botocore.exceptions import ClientError
 from basepair.modules.aws.handler.exception import ExceptionHandler
 from basepair.modules.aws.service import Service
 
-class SM(Service): # pylint: disable=too-few-public-methods
-  '''Wrapper for CW services'''
-  def __init__(self, cfg):
-    super().__init__(cfg, 'SM')
-    self.client = self.session.client(**{
-      'config': Config(retries={'max_attempts': 0, 'mode': 'standard'}),
-      'service_name': 'secretsmanager',
-    })
 
-  def delete(self, secret_id, force=False):
-    '''Delete secrets'''
-    try:
-      args = {"SecretId": secret_id}
-      if force:
-        args["ForceDeleteWithoutRecovery"] = force
-      response = self.client.delete_secret(**args)
-    except ClientError as error:
-      response = self.get_log_msg({
-        'exception': error,
-        'msg': f'Not able to delete secret with id {secret_id}.',
-      })
-      if ExceptionHandler.is_throttled_error(exception=error):
-        raise error
-    return response
+class SM(Service):  # pylint: disable=too-few-public-methods
+	"""Wrapper for CW services"""
 
-  def get(self, secret_id, use_cache=True):
-    '''Get the values for the given secret key'''
-    key = f'{secret_id}'
-    cache_file = f'/tmp/{key}'
-    twelve_hours_ago = time.time() - 43200 # 43200 seconds = 12hs
-    if use_cache and os.path.isfile(cache_file):
-      # reading the price from cache
-      cache = {}
-      with open(cache_file, 'r', encoding='utf-8') as file:
-        cache = json.load(file)
-      # expire the cache if needed
-      filte_stats = os.stat(cache_file)
-      if filte_stats.st_mtime < twelve_hours_ago:
-        os.unlink(cache_file)
-      # returning cached price
-      return cache.get('SecretString', {})
+	def __init__(self, cfg):
+		super().__init__(cfg, "SM")
+		self.client = self.session.client(
+			**{
+				"config": Config(retries={"max_attempts": 0, "mode": "standard"}),
+				"service_name": "secretsmanager",
+			}
+		)
 
-    try:
-      response = self.client.get_secret_value(SecretId=secret_id)
-    except ClientError as error:
-      response = self.get_log_msg({
-        'exception': error,
-        'msg': f'Not able to get secret with id {secret_id}.',
-      })
-      if ExceptionHandler.is_throttled_error(exception=error):
-        raise error
-      return response
-    secret = response.get('SecretString')
-    if secret and use_cache:
-      with open(cache_file, 'w', encoding='utf-8') as file:
-        json_content = json.dumps({'SecretString': secret})
-        file.write(json_content)
-    return secret
+	def delete(self, secret_id, force=False):
+		"""Delete secrets"""
+		try:
+			args = {"SecretId": secret_id}
+			if force:
+				args["ForceDeleteWithoutRecovery"] = force
+			response = self.client.delete_secret(**args)
+		except ClientError as error:
+			response = self.get_log_msg(
+				{
+					"exception": error,
+					"msg": f"Not able to delete secret with id {secret_id}.",
+				}
+			)
+			if ExceptionHandler.is_throttled_error(exception=error):
+				raise error
+		return response
 
-  def put(self, secret_id, value, tags=None):
-    '''Set value to secret key'''
-    try:
-      args = {
-        "Name": secret_id,
-        "SecretString": value,
-      }
-      if tags:
-        args["Tags"] = tags
-      response = self.client.create_secret(**args)
-    except ClientError as error:
-      response = self.get_log_msg({
-        'exception': error,
-        'msg': f'Not able to get secret with id {secret_id}.',
-      })
-      if ExceptionHandler.is_throttled_error(exception=error):
-        raise error
-    return response
+	def get(self, secret_id, use_cache=True):
+		"""Get the values for the given secret key"""
+		key = f"{secret_id}"
+		cache_file = f"/tmp/{key}"
+		twelve_hours_ago = time.time() - 43200  # 43200 seconds = 12hs
+		if use_cache and os.path.isfile(cache_file):
+			# reading the price from cache
+			cache = {}
+			with open(cache_file, "r", encoding="utf-8") as file:
+				cache = json.load(file)
+			# expire the cache if needed
+			filte_stats = os.stat(cache_file)
+			if filte_stats.st_mtime < twelve_hours_ago:
+				os.unlink(cache_file)
+			# returning cached price
+			return cache.get("SecretString", {})
 
+		try:
+			response = self.client.get_secret_value(SecretId=secret_id)
+		except ClientError as error:
+			response = self.get_log_msg(
+				{
+					"exception": error,
+					"msg": f"Not able to get secret with id {secret_id}.",
+				}
+			)
+			if ExceptionHandler.is_throttled_error(exception=error):
+				raise error
+			return response
+		secret = response.get("SecretString")
+		if secret and use_cache:
+			with open(cache_file, "w", encoding="utf-8") as file:
+				json_content = json.dumps({"SecretString": secret})
+				file.write(json_content)
+		return secret
+
+	def put(self, secret_id, value, tags=None):
+		"""Set value to secret key"""
+		try:
+			args = {
+				"Name": secret_id,
+				"SecretString": value,
+			}
+			if tags:
+				args["Tags"] = tags
+			response = self.client.create_secret(**args)
+		except ClientError as error:
+			response = self.get_log_msg(
+				{
+					"exception": error,
+					"msg": f"Not able to get secret with id {secret_id}.",
+				}
+			)
+			if ExceptionHandler.is_throttled_error(exception=error):
+				raise error
+		return response

--- a/app/basepair/modules/aws/sm.py
+++ b/app/basepair/modules/aws/sm.py
@@ -22,6 +22,22 @@ class SM(Service): # pylint: disable=too-few-public-methods
       'service_name': 'secretsmanager',
     })
 
+  def delete(self, secret_id, force=False):
+    '''Delete secrets'''
+    try:
+      args = {"SecretId": secret_id}
+      if force:
+        args["ForceDeleteWithoutRecovery"] = force
+      response = self.client.delete_secret(**args)
+    except ClientError as error:
+      response = self.get_log_msg({
+        'exception': error,
+        'msg': f'Not able to delete secret with id {secret_id}.',
+      })
+      if ExceptionHandler.is_throttled_error(exception=error):
+        raise error
+    return response
+
   def get(self, secret_id, use_cache=True):
     '''Get the values for the given secret key'''
     key = f'{secret_id}'

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,7 +1,8 @@
 appnope==0.1.0
 awscli==1.25.38
-boto3==1.24.38
 backports.shutil-get-terminal-size==1.0.0
+black-with-tabs==22.10.0
+boto3==1.24.38
 certifi==2023.7.22
 chardet==3.0.4
 colorama==0.3.7
@@ -26,8 +27,8 @@ pickleshare==0.7.4
 ptyprocess==0.5.2
 pyasn1==0.4.2
 Pygments==2.15.0
-pylint==2.6.0
-pylint-plugin-utils==0.6
+pylint==3.0.1
+pylint-plugin-utils==0.8.2
 python-dateutil==2.7.3
 PyYAML==5.3.1
 requests==2.31.0


### PR DESCRIPTION
## Motivation
There is the edge case where analysis are interrupted without worker being call not even once. In tht case secrets are not being removed and the restart analysis will fail because the existing secrets holds already deprecated temporary iam credentials.

## How this PR address the issue?
We add a remove secret call for the ec2 driver when temporary iam credentials are removed. if the call result in an error we ignore it because we assume the secret was already removed.

## Requires:
- https://github.com/basepair/webapp/pull/2270

## TODO:
- Test