### PR TITLE
BugFix: Not all Samples downloading from cli to local storage

### DIFF
--- a/app/basepair/__init__.py
+++ b/app/basepair/__init__.py
@@ -12,7 +12,7 @@ from .infra.webapp import Analysis, File, Gene, Genome, GenomeFile, Host, Module
 # Exposing the storage wrapper
 
 __title__ = 'basepair'
-__version__ = '2.2.8'
+__version__ = '2.2.8a'
 __copyright__ = 'Copyright [2017] - [2024] Basepair INC'
 
 

--- a/app/basepair/api.py
+++ b/app/basepair/api.py
@@ -1023,8 +1023,11 @@ class BpApi(): # pylint: disable=too-many-instance-attributes,too-many-public-me
       if not files:
         eprint('Warning: No files present for sample with id {}'.format(uid))
         return False
+      results = []
       for file_i in files:
-        return self.download_file(file_i, file_type=file_type, uid=uid, dirname=outdir)
+        result = self.download_file(file_i, file_type=file_type, uid=uid, dirname=outdir)
+        results.append(result)
+      return all(results)
     except Exception:# pylint: disable=broad-except
       return False
 


### PR DESCRIPTION
Ticket : https://basepairtech.atlassian.net/browse/WEBAPP-727
Description - The user cannot download the complete sample from the Basepair CLI. Only forward or reverse file is downloaded to the local storage.

Steps to Replicate the issue -
1. Download the Basepair CLI via terminal
2. Enter the command basepair sample download -u 105124 -c ~/.ssh/super_user_basepair.config.json

 
Expected Result - The complete sample should be downloaded to the user’s local storage
Actual Result - Either forward or reverse sample is downloaded to the user’s

```
Using config file /Users/basepair/.ssh/super_user_basepair.config.json
downloading ./ Control1_2.fastq.gz
copying from s3 bucket to ./Control1_2.fastq.gz
Error: b'fatal error: An error occurred (403) when calling the HeadObject operation: Forbidden\n'
Return code: 1
retrying in 3 seconds.
```